### PR TITLE
Increase the bootup timeout from 1 min to 5

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -86,7 +86,7 @@ func New(dir string) (*Server, error) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Minute)
 	defer cancel()
 
 	if err := app.Ready(ctx); err != nil {


### PR DESCRIPTION
When booting dqlite may need to sync some snapshots. One minute may not be enough for this so we give it more slack.